### PR TITLE
Brute

### DIFF
--- a/ChoreChallenge/Framework/Achievements/Brute.cs
+++ b/ChoreChallenge/Framework/Achievements/Brute.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Monsters;
+using static StardewValley.Debris;
+
+namespace ChoreChallenge.Framework.Achievements
+{
+	public class Brute : IAchievement
+	{
+        private string LastCritTime;
+        private static Brute instance;
+        public Brute()
+            : base("Brute", 5)
+        {
+            instance = this;
+
+        }
+
+        public override void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GameLocation), "damageMonster",
+                    new Type[] { typeof(Rectangle), typeof(int), typeof(int), typeof(bool), typeof(float), typeof(int), typeof(float), typeof(float), typeof(bool), typeof(Farmer) }),
+                prefix: new HarmonyMethod(typeof(Brute), nameof(Brute.Prefix_damageMonster)),
+                postfix: new HarmonyMethod(typeof(Brute), nameof(Brute.Postfix_damageMonster))
+                );
+        }
+
+        public static bool Prefix_damageMonster(GameLocation __instance, out List<Tuple<Monster,int>> __state)
+        {
+            __state = new List<Tuple<Monster, int>>();
+            if (instance.HasSeen) return true;
+
+            foreach (var character in __instance.characters)
+            {
+                if (character is Monster monster)
+                {
+                    __state.Add(Tuple.Create(monster, monster.Health));
+                }
+            }
+            return true;
+        }
+
+        public static void Postfix_damageMonster(GameLocation __instance, bool __result, List<Tuple<Monster, int>> __state)
+        {
+            if (!__result || instance.HasSeen) return;
+            foreach (var tuple in __state)
+            {
+                // the monster has dropped this
+                var monster = tuple.Item1;
+                var originalHealth = tuple.Item2;
+                int damageAmount = originalHealth - monster.Health;
+                if (damageAmount >= 100)
+                {
+                    foreach (var debris in __instance.debris.Where(d => d.debrisType.Value == DebrisType.NUMBERS))
+                    {
+                        if (
+                            debris.toHover == monster &&
+                            debris.chunkType.Value == damageAmount &&
+                            debris.nonSpriteChunkColor.Value != Color.Yellow
+                            )
+                        {
+                            instance.HasSeen = true;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/*
+ * damageMonster
+//public bool damageMonster(Microsoft.Xna.Framework.Rectangle areaOfEffect, int minDamage, int maxDamage, bool isBomb, float knockBackModifier, int addedPrecision, float critChance, float critMultiplier, bool triggerMonsterInvincibleTimer, Farmer who)
+*/

--- a/ChoreChallenge/Framework/Achievements/Brute.cs
+++ b/ChoreChallenge/Framework/Achievements/Brute.cs
@@ -55,14 +55,24 @@ namespace ChoreChallenge.Framework.Achievements
                 var monster = tuple.Item1;
                 var originalHealth = tuple.Item2;
                 int damageAmount = originalHealth - monster.Health;
+
                 if (damageAmount >= 100)
                 {
                     foreach (var debris in __instance.debris.Where(d => d.debrisType.Value == DebrisType.NUMBERS))
                     {
+                        /* GameLocation.damageMonster(...)
+                        if (damageAmount == -1) {
+                            ...
+                        } else {
+                            ...
+                            debris.Add(new Debris(damageAmount, new Vector2(monsterBox.Center.X + 16, monsterBox.Center.Y), crit ? Color.Yellow : new Color(255, 130, 0), crit ? (1f + (float)damageAmount / 300f) : 1f, monster));
+                            ...
+                        }
+                        */
                         if (
                             debris.toHover == monster &&
                             debris.chunkType.Value == damageAmount &&
-                            debris.nonSpriteChunkColor.Value != Color.Yellow
+                            debris.nonSpriteChunkColor.Value != Color.Yellow // this color is set for the crit debris
                             )
                         {
                             instance.HasSeen = true;

--- a/ChoreChallenge/Framework/Achievements/RareAndValuable.cs
+++ b/ChoreChallenge/Framework/Achievements/RareAndValuable.cs
@@ -17,7 +17,6 @@ namespace ChoreChallenge.Framework.Achievements
 
         public override void OnUpdate()
         {
-            instance.Monitor.Log($"{InitialShards}/{Game1.stats.PrismaticShardsFound}", LogLevel.Alert);
             if (Game1.stats.PrismaticShardsFound >= InitialShards + 2)
             {
                 instance.HasSeen = true;

--- a/ChoreChallenge/Framework/Achievements/RestAndRelaxation.cs
+++ b/ChoreChallenge/Framework/Achievements/RestAndRelaxation.cs
@@ -41,13 +41,13 @@ namespace ChoreChallenge.Framework.Achievements
                 {
                     instance.HasSeen = true;
                 }
-                instance.Monitor.Log($"{nameof(RestAndRelaxation)} - swimming, current stamina {farmer.Stamina}, starting {instance.startingEnergy}, regained {instance.energyRegained}", LogLevel.Debug);
+                //instance.Monitor.Log($"{nameof(RestAndRelaxation)} - swimming, current stamina {farmer.Stamina}, starting {instance.startingEnergy}, regained {instance.energyRegained}", LogLevel.Debug);
             }
             else
             {
                 instance.energyRegained = 0;
                 instance.startingEnergy = null;
-                instance.Monitor.Log($"{nameof(RestAndRelaxation)} - stopped swimming", LogLevel.Debug);
+                //instance.Monitor.Log($"{nameof(RestAndRelaxation)} - stopped swimming", LogLevel.Debug);
             }
         }
     }

--- a/ChoreChallenge/ModEntry.cs
+++ b/ChoreChallenge/ModEntry.cs
@@ -49,6 +49,7 @@ namespace ChoreChallenge
             Achievements.Add(new RareAndValuable());
             Achievements.Add(new TwoTilesOfRange());
             Achievements.Add(new RestAndRelaxation());
+            Achievements.Add(new Brute());
 
 
             var harmony = new Harmony(this.ModManifest.UniqueID);


### PR DESCRIPTION
Unfortunately crits aren't really captured outside the `GameLocation.damageMonster` function. The way this works is by tracking monster health before and after the `GameLocation.damageMonster` function is triggered.

For any monster that has `damageAmount >= 100`: 
* find all debris with type `DebrisType.NUMBER` with that `damageAmount` associated with the monster via `debris.ToHover`
* Check the `debris.nonSpriteChunkColor.Value`
  * `Color.Yellow` is a crit (`Color(255,255,0)`)
  * `Color(255,130,0)` is a non-crit